### PR TITLE
Fix loggin connection info, not use turntable case

### DIFF
--- a/lib/active_record/turntable/active_record_ext/log_subscriber.rb
+++ b/lib/active_record/turntable/active_record_ext/log_subscriber.rb
@@ -35,7 +35,15 @@ module ActiveRecord::Turntable
             return if 'SCHEMA' == payload[:name]
 
             name    = '%s (%.1fms)' % [payload[:name], event.duration]
-            shard = '[Shard: %s]' % (event.payload[:turntable_shard_name] ? event.payload[:turntable_shard_name] : nil)
+
+            connection = if event.payload[:turntable_shard_name]
+                           '[Shard: %s]' % event.payload[:turntable_shard_name]
+                         elsif event.payload[:connection_name]
+                           '[%s]' % event.payload[:connection_name]
+                         else
+                           '[unknown]'
+                         end
+
             sql     = payload[:sql].squeeze(' ')
             binds   = nil
 
@@ -47,18 +55,17 @@ module ActiveRecord::Turntable
 
             if odd?
               name = color(name, ActiveRecord::LogSubscriber::CYAN, true)
-              shard = color(shard, ActiveRecord::LogSubscriber::CYAN, true)
+              connection = color(connection, ActiveRecord::LogSubscriber::CYAN, true)
               sql  = color(sql, nil, true)
             else
               name = color(name, ActiveRecord::LogSubscriber::MAGENTA, true)
-              shard = color(shard, ActiveRecord::LogSubscriber::MAGENTA, true)
+              connection = color(connection, ActiveRecord::LogSubscriber::MAGENTA, true)
             end
 
-            debug "  #{name} #{shard} #{sql}#{binds}"
+            debug "  #{name} #{connection} #{sql}#{binds}"
           end
         end
       end
     end
   end
 end
-


### PR DESCRIPTION
db-charmerとturntableの複合によって、SQLのloggingにdb-charmerを利用したmaster/slaveの接続先情報が出力されていないのを改修
## master/slaveが設定してある場合
### before

```
msg:UserReceive Load (0.3ms) [Shard: ] SELECT `user_receives`.* FROM `user_receives` WHERE `user_receives`.`user_id` = 1
```

このように`Shard`を利用していないのでShardの情報だけ出力され、肝心なdb-charmerの情報が欠落している。
### after

```
msg:UserReceive Load (0.2ms) [user_receive_slave1] SELECT `user_receives`.* FROM `user_receives` WHERE `user_receives`.`user_id` = 1
```

`user_receive_slave1`が出力されるようになった。

masterを参照すると

```
msg:SQL (0.2ms) [user_receive] SELECT `user_receives`.`id` FROM `user_receives` WHERE `user_receives`.`user_id` = 1
```

のようにmasterのコネクション情報が出力される。
## turntableを利用したShard構成のログ

Shardを利用している場合は、今まで通り

```
msg:[ActiveRecord::Turntable] Sending method: select_all, sql: #<Arel::SelectManager:0x007fee0ac47e80>, shards: ["user_shard_1", "user_shard_2"]
msg:User Load (0.3ms) [Shard: user_shard_1] SELECT `users`.* FROM `users`
msg:User Load (0.2ms) [Shard: user_shard_2] SELECT `users`.* FROM `users`
```
