### PR TITLE
sequencer へのmigrate を指定したcluster のsequencer に限定する

### DIFF
--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -65,7 +65,7 @@ module ActiveRecord::Turntable::Migration
     config = ActiveRecord::Base.configurations
     @@current_shard = nil
     shards = (self.class.target_shards||=[]).flatten.uniq.compact
-    if self.class.target_shards.blank?
+    if self.class.target_shards.blank? || self.class.target_seqs.blank?
       return migrate_without_turntable(direction)
     end
     shards_conf = shards.map do |shard|

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -64,10 +64,11 @@ module ActiveRecord::Turntable::Migration
   def migrate_with_turntable(direction)
     config = ActiveRecord::Base.configurations
     @@current_shard = nil
-    shards = (self.class.target_shards||=[]).flatten.uniq.compact
     if self.class.target_shards.blank? || self.class.target_seqs.blank?
       return migrate_without_turntable(direction)
     end
+
+    shards = (self.class.target_shards||=[]).flatten.uniq.compact
     shards_conf = shards.map do |shard|
       config[ActiveRecord::Turntable::RackupFramework.env||"development"]["shards"][shard]
     end

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -39,28 +39,17 @@ module ActiveRecord::Turntable::Migration
   module ShardDefinition
     def clusters(*cluster_names)
       config = ActiveRecord::Base.turntable_config
-      (self.target_shards ||= []) <<
-        if cluster_names.first == :all
-          config['clusters'].map do |name, cluster_conf|
-            cluster_conf["shards"].map {|shard| shard["connection"]}
-          end
-        else
-          cluster_names.map do |cluster_name|
-            config['clusters'][cluster_name]["shards"].map do |shard|
-              shard["connection"]
-            end
-          end
+      if cluster_names.first == :all
+        config['clusters'].map do |name, cluster_conf|
+          (self.target_shards ||= []) << cluster_conf["shards"].map { |shard| shard["connection"] }
+          (self.target_seqs ||= []) << cluster_conf["seq"]["connection"]
         end
-      (self.target_seqs ||= []) <<
-        if cluster_names.first == :all
-          config['clusters'].map do |name, cluster_conf|
-            cluster_conf["seq"]["connection"]
-          end
-        else
-          cluster_names.map do |cluster_name|
-            config['clusters'][cluster_name]["seq"]["connection"]
-          end
+      else
+        cluster_names.map do |cluster_name|
+          (self.target_shards ||= []) << config['clusters'][cluster_name]["shards"].map { |shard| shard["connection"] }
+          (self.target_seqs ||= []) << config['clusters'][cluster_name]["seq"]["connection"]
         end
+      end
     end
 
     def shards(*connection_names)

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -65,14 +65,14 @@ module ActiveRecord::Turntable::Migration
     config = ActiveRecord::Base.configurations
     @@current_shard = nil
     shards = (self.class.target_shards||=[]).flatten.uniq.compact
-    seqs = (self.class.target_seqs||=[]).flatten.uniq.compact
-    if self.class.target_shards.blank? || self.class.target_seqs.blank?
+    if self.class.target_shards.blank?
       return migrate_without_turntable(direction)
     end
-
     shards_conf = shards.map do |shard|
       config[ActiveRecord::Turntable::RackupFramework.env||"development"]["shards"][shard]
     end
+
+    seqs = (self.class.target_seqs||=[]).flatten.uniq.compact
     seqs_conf = config[ActiveRecord::Turntable::RackupFramework.env||"development"]["seq"].select { |key, val| seqs.include?(key) }
     shards_conf += seqs_conf.values
 


### PR DESCRIPTION
sequencer へのmigrate (`create_sequence_for` など） が現在はmigrate ファイルで指定したclutster 以外のsequencer にも全て実行されているが、これを指定したclusterのsequencer のみに修正したいと思います。
default のdatabase にはこれまでどおりmigrateされます。

複数のsequencer があり環境によってはそれらのdatabaseを同居させようとした複数回同じmigrate が実行されてmigrate に失敗してしまうため。
