### PR TITLE
for incompatibility issue with newrelic

### DIFF
--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Turntable
         protected
 
         if ActiveRecord::VERSION::STRING < '3.1'
-          def log_without_newrelic_instrumentation(sql, name)
+          def log(sql, name)
             name ||= "SQL"
             @instrumenter.instrument("sql.active_record",
                                      :sql => sql, :name => name, :connection_id => object_id,
@@ -20,7 +20,7 @@ module ActiveRecord::Turntable
             raise translate_exception(e, message)
           end
         else
-          def log_without_newrelic_instrumentation(sql, name = "SQL", binds = [])
+          def log(sql, name = "SQL", binds = [])
             @instrumenter.instrument(
                                      "sql.active_record",
                                      :sql           => sql,
@@ -36,8 +36,9 @@ module ActiveRecord::Turntable
             raise exception
           end
         end
-        if not defined?(::NewRelic)
-          alias_method :log, :log_without_newrelic_instrumentation
+        if defined?(::NewRelic)
+          alias_method :log_without_newrelic_instrumentation, :log
+          alias_method :log, :log_with_newrelic_instrumentation
         end
       end
 

--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -37,8 +37,8 @@ module ActiveRecord::Turntable
           end
         end
 
-        alias_method_chain :log, :newrelic_instrumentation if defined?(::NewRelic)
-
+        alias_method_chain :log, :newrelic_instrumentation if method_defined?(:log_with_newrelic_instrumentation)
+        
       end
 
       def turntable_shard_name=(name)

--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -36,10 +36,9 @@ module ActiveRecord::Turntable
             raise exception
           end
         end
-        if defined?(::NewRelic)
-          alias_method :log_without_newrelic_instrumentation, :log
-          alias_method :log, :log_with_newrelic_instrumentation
-        end
+
+        alias_method_chain :log, :newrelic_instrumentation if defined?(::NewRelic)
+
       end
 
       def turntable_shard_name=(name)

--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Turntable
         protected
 
         if ActiveRecord::VERSION::STRING < '3.1'
-          def log(sql, name)
+          def log_without_newrelic_instrumentation(sql, name)
             name ||= "SQL"
             @instrumenter.instrument("sql.active_record",
                                      :sql => sql, :name => name, :connection_id => object_id,
@@ -20,7 +20,7 @@ module ActiveRecord::Turntable
             raise translate_exception(e, message)
           end
         else
-          def log(sql, name = "SQL", binds = [])
+          def log_without_newrelic_instrumentation(sql, name = "SQL", binds = [])
             @instrumenter.instrument(
                                      "sql.active_record",
                                      :sql           => sql,
@@ -35,6 +35,9 @@ module ActiveRecord::Turntable
             exception.set_backtrace e.backtrace
             raise exception
           end
+        end
+        if not defined?(::NewRelic)
+          alias_method :log, :log_without_newrelic_instrumentation
         end
       end
 


### PR DESCRIPTION
I want to solve the incompatibility issue with newrelic rpm. I can't see mysql graph when using `rpm` agent.
##### Problem

The problem happened when this gem is loaded later than the agent. Both of them, `turntable` and `rpm`, change log method.  `rpm` rename log method for logging mysql metric -> `turnable` rewrites the log method that the agent aliases to.
https://github.com/newrelic/rpm/blob/master/lib/new_relic/agent/instrumentation/active_record.rb#L32
https://github.com/monsterstrike/activerecord-turntable/blob/tiepadrino/lib/active_record/turntable/active_record_ext/abstract_adapter.rb#L9
##### How to fix

If using `rpm` agent, `turnable` rewrites `log_without_newrelic_instrumentation` instead of `log` method
If not, `log` method will be rename to `log_without_newrelic_instrumentation` method, `turnable` rewrites `log`, nothing changed.
