### PR TITLE
[WIP] redisによるsequencerを追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ gemfile:
   - gemfiles/rails3_0.gemfile
   - gemfiles/rails3_1.gemfile
   - gemfiles/rails3_2.gemfile
+services:
+  - redis-server
 before_script:
   - bundle exec rake turntable:db:reset
 script: bundle exec rake spec

--- a/README.rdoc
+++ b/README.rdoc
@@ -183,23 +183,75 @@ add turntable [shard_key_name] to the model class:
        (0.2ms) [Shard: user_shard_3] SELECT COUNT(*) FROM `users`
     => 1
 
-=== Sequencer
+== Sequencer
+
 Sequencer provides generating global IDs.
+
+Turntable has follow 2 sequencers currently:
+
+* :mysql - Use database table to generate ids.
+* :redis - Use redis to generate ids.
+
+=== Mysql example
+
+First, add configuration to turntable.yml and database.yml
+
+* database.yml
+
+  development:
+    ...
+    seq: # <-- sequence database definition
+      user_seq_1:
+        <<: *spec
+        database: sample_app_user_seq_development
+
+* turntable.yml
+
+  development:
+    clusters:
+      user_cluster: # <-- cluster name
+        ....
+        seq:
+          user_seq: # <-- sequencer name
+            seq_type: mysql # <-- sequencer type
+            connection: user_seq_1 # <-- sequencer database connection
 
 Add below to the migration:
 
-      create_sequence_for(:users) # <-- this line creates sequence table
+  create_sequence_for(:users) # <-- this line creates sequence table named `users_id_seq`
 
-This will creates sequence table.
-
-Next, add sequencer to the model:
+Next, add sequencer definition to the model:
 
   class User < ActiveRecord::Base
     turntable :id
-    sequencer # <-- this line enables sequencer module
+    sequencer :user_seq # <-- this line enables sequencer module
     has_one :status
   end
 
+=== Redis example
+
+First, add redis gem to your Gemfile:
+
+  gem 'redis'
+
+Then, add configuration to turntable.yml:
+
+* turntable.yml
+
+  development:
+    clusters:
+      user_cluster: # <-- cluster name
+        ....
+        seq:
+          seq_type: redis
+          connection: redis_sequencer # <-- redis sequencer name
+        shards:
+          - connection: redis_shard_1
+          - connection: redis_shard_2
+
+    redis: # <-- redis sequencer definition
+      redis_sequencer: # <-- redis sequencer name
+        host: 127.0.0.1 # <-- redis connection config
 
 === Transaction
     > user = User.find(2)

--- a/README.rdoc
+++ b/README.rdoc
@@ -246,8 +246,8 @@ Then, add configuration to turntable.yml:
           seq_type: redis
           connection: redis_sequencer # <-- redis sequencer name
         shards:
-          - connection: redis_shard_1
-          - connection: redis_shard_2
+          - connection: user_shard_1
+          - connection: user_shard_2
 
     redis: # <-- redis sequencer definition
       redis_sequencer: # <-- redis sequencer name

--- a/Rakefile
+++ b/Rakefile
@@ -89,6 +89,14 @@ namespace :turntable do
           t.datetime   :deleted_at, :default => nil
         end
         ActiveRecord::Base.connection.create_sequence_for :archived_cards_users
+
+        ActiveRecord::Base.connection.create_table :friends do |t|
+          t.string :nickname
+          t.string :thumbnail_url
+          t.datetime :joined_at
+          t.datetime :deleted_at
+          t.timestamps
+        end
       end
     end
 

--- a/activerecord-turntable.gemspec
+++ b/activerecord-turntable.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<pry>, [">= 0"])
   s.add_development_dependency(%q<guard-rspec>, [">= 0"])
   s.add_development_dependency(%q<coveralls>, [">= 0"])
+  s.add_development_dependency(%q<redis>, [">= 3.1.0"])
 
   if RUBY_PLATFORM =~ /darwin/
     s.add_development_dependency(%q<growl>, [">= 0"])

--- a/lib/active_record/turntable/cluster.rb
+++ b/lib/active_record/turntable/cluster.rb
@@ -16,8 +16,11 @@ module ActiveRecord::Turntable
       @master_shard = MasterShard.new(klass)
 
       # setup sequencer
-      if (seq = (@options[:seq] || @config[:seq]))
-        @seq_shard = SeqShard.new(seq)
+      seq = (@options[:seq] || @config[:seq])
+      if seq
+        if seq.values.size > 0 && seq.values.first["seq_type"] == "mysql"
+          @seq_shard = SeqShard.new(seq.values.first)
+        end
       end
 
       # setup shards

--- a/lib/active_record/turntable/error.rb
+++ b/lib/active_record/turntable/error.rb
@@ -2,6 +2,7 @@ module ActiveRecord::Turntable
   class Error < StandardError; end
   class NotImplementedError < Error; end
   class SequenceNotFoundError < Error; end
+  class SequenceValueBrokenError < Error; end
   class CannotSpecifyShardError < Error; end
   class MasterShardNotConnected < Error; end
   class UnknownOperatorError < Error; end

--- a/lib/active_record/turntable/sequencer.rb
+++ b/lib/active_record/turntable/sequencer.rb
@@ -7,9 +7,11 @@ module ActiveRecord::Turntable
   class Sequencer
     autoload :Api, "active_record/turntable/sequencer/api"
     autoload :Mysql, "active_record/turntable/sequencer/mysql"
+    autoload :Redis, "active_record/turntable/sequencer/redis"
     @@sequence_types = {
       :api => Api,
-      :mysql => Mysql
+      :mysql => Mysql,
+      :redis => Redis
     }
 
     @@sequences = {}
@@ -17,10 +19,15 @@ module ActiveRecord::Turntable
     cattr_reader :sequences, :tables
 
     def self.build(klass)
-      seq_config_name = ActiveRecord::Base.turntable_config["clusters"][klass.turntable_cluster_name.to_s]["seq"]["connection"]
-      seq_config = ActiveRecord::Base.configurations[ActiveRecord::Turntable::RackupFramework.env]["seq"][seq_config_name]
+      seq_config = ActiveRecord::Base.turntable_config["clusters"][klass.turntable_cluster_name.to_s]["seq"]
       seq_type = (seq_config["seq_type"] ? seq_config["seq_type"].to_sym : :mysql)
-      @@tables[klass.table_name] ||= (@@sequences[sequence_name(klass.table_name, klass.primary_key)] ||= @@sequence_types[seq_type].new(klass, seq_config))
+      seq_config_name = seq_config["connection"]
+      if seq_type == :mysql
+        seq_connection_config = ActiveRecord::Base.configurations[ActiveRecord::Turntable::RackupFramework.env]["seq"][seq_config_name]
+      else
+        seq_connection_config = ActiveRecord::Base.turntable_config[seq_type][seq_config_name]
+      end
+      @@tables[klass.table_name] ||= (@@sequences[sequence_name(klass.table_name, klass.primary_key)] ||= @@sequence_types[seq_type].new(klass, seq_connection_config))
     end
 
     def self.has_sequencer?(table_name)
@@ -28,7 +35,7 @@ module ActiveRecord::Turntable
     end
 
     def self.sequence_name(table_name, pk)
-      "#{ table_name}_#{pk || 'id'}_seq"
+      "#{table_name}_#{pk || 'id'}_seq"
     end
 
     def self.table_name(seq_name)

--- a/lib/active_record/turntable/sequencer/redis.rb
+++ b/lib/active_record/turntable/sequencer/redis.rb
@@ -22,7 +22,7 @@ module ActiveRecord::Turntable
       def current_sequence_value(sequence_name)
         id = client.get(sequence_name)
         raise SequenceNotFoundError if id.nil?
-        return id
+        return Integer(id) rescue raise SequenceValueBrokenError
       end
 
       private

--- a/lib/active_record/turntable/sequencer/redis.rb
+++ b/lib/active_record/turntable/sequencer/redis.rb
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# redisを利用しての採番
+#
+module ActiveRecord::Turntable
+  class Sequencer
+    class Redis < Sequencer
+      @@clients = {}
+
+      def initialize(klass, options = {})
+        require "redis"
+        @klass = klass
+        @option = options
+      end
+
+      def next_sequence_value(sequence_name, offset = 1)
+        client.incrby(sequence_name, offset)
+      end
+
+      def current_sequence_value(sequence_name)
+        id = client.get(sequence_name)
+        raise SequenceNotFoundError if id.nil?
+        return id
+      end
+
+      private
+
+      def client
+        @@clients[@option] ||= ::Redis.new(@option)
+      end
+    end
+  end
+end

--- a/spec/active_record/turntable/sequencer/redis_spec.rb
+++ b/spec/active_record/turntable/sequencer/redis_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require 'redis'
+
+describe ActiveRecord::Turntable::Sequencer::Redis do
+  let (:sequencer) { ActiveRecord::Turntable::Sequencer::Redis.new(Object, {host: "127.0.0.1"})}
+  let (:sequencer_name) { "test_sequencer" }
+
+  context "exists sequencer key" do
+    before do
+      client = Redis.new(host: "127.0.0.1")
+      client.set(sequencer_name, 100)
+    end
+
+    describe "#next_sequence_value" do
+      context "when use default offset" do
+        it "return 101" do
+          expect(sequencer.next_sequence_value(sequencer_name)).to eq 101
+        end
+      end
+      context "when offset 100" do
+        it "return 200" do
+          expect(sequencer.next_sequence_value(sequencer_name, 100)).to eq 200
+        end
+      end
+    end
+
+    describe "#current_sequence_value" do
+      it do
+        expect(sequencer.current_sequence_value(sequencer_name)).to eq 100
+      end
+    end
+  end
+
+  context "not exists sequencer key" do
+    before do
+      client = Redis.new(host: "127.0.0.1")
+      client.del(sequencer_name)
+    end
+
+    describe "#next_sequence_value" do
+      it "raise ActiveRecord::Turntable::SequenceNotFoundError" do
+        expect { sequencer.next_sequence_value(sequencer_name) }.to raise_error(ActiveRecord::Turntable::SequenceNotFoundError)
+      end
+    end
+
+    describe "#current_sequence_value" do
+      it "raise ActiveRecord::Turntable::SequenceNotFoundError" do
+        expect { sequencer.current_sequence_value(sequencer_name) }.to raise_error(ActiveRecord::Turntable::SequenceNotFoundError)
+      end
+    end
+  end
+
+  context "sequencer value is not number" do
+    before do
+      client = Redis.new(host: "127.0.0.1")
+      client.set(sequencer_name, "abc")
+    end
+
+    describe "#next_sequence_value" do
+      it "raise Redis::CommandError" do
+        expect { sequencer.next_sequence_value(sequencer_name) }.to raise_error(Redis::CommandError)
+      end
+    end
+
+    describe "#current_sequence_value" do
+      it "raise ActiveRecord::Turntable::SequenceValueBrokenError" do
+        expect { sequencer.current_sequence_value(sequencer_name) }.to raise_error(ActiveRecord::Turntable::SequenceValueBrokenError)
+      end
+    end
+  end
+end

--- a/spec/active_record/turntable/sequencer_spec.rb
+++ b/spec/active_record/turntable/sequencer_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe ActiveRecord::Turntable::Sequencer do
   before(:all) do

--- a/spec/active_record/turntable/sequencer_spec.rb
+++ b/spec/active_record/turntable/sequencer_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'pry'
+
+describe ActiveRecord::Turntable::Sequencer do
+  before(:all) do
+    reload_turntable!(File.join(File.dirname(__FILE__), "../../config/turntable.yml"))
+  end
+
+  before do
+    establish_connection_to("test")
+  end
+
+  describe "#build" do
+    context "when sequencer type mysql" do
+      it "return ActiveRecord::Turntable::Sequencer::Mysql" do
+        expect(ActiveRecord::Turntable::Sequencer.build(User)).to be_an_instance_of(ActiveRecord::Turntable::Sequencer::Mysql)
+      end
+    end
+
+    context "when sequencer type redis" do
+      it "return ActiveRecord::Turntable::Sequencer::Redis" do
+        expect(ActiveRecord::Turntable::Sequencer.build(Friend)).to be_an_instance_of(ActiveRecord::Turntable::Sequencer::Redis)
+      end
+    end
+  end
+end

--- a/spec/active_record/turntable_spec.rb
+++ b/spec/active_record/turntable_spec.rb
@@ -8,7 +8,7 @@ describe ActiveRecord::Turntable do
   context "#config_file" do
     it "should return Rails.root/config/turntable.yml default" do
       unless defined?(::Rails); class ::Rails; end; end
-      stub(Rails).root { "/path/to/rails_root" }
+      stub(ActiveRecord::Turntable::RackupFramework).root { "/path/to/rails_root" }
       ActiveRecord::Base.turntable_config_file = nil
       ActiveRecord::Base.turntable_config_file.should == "/path/to/rails_root/config/turntable.yml"
     end

--- a/spec/config/database.yml
+++ b/spec/config/database.yml
@@ -43,3 +43,20 @@ test:
       port: 3306
       encoding: utf8
       database: turntable3_test
+    redis_shard_1:
+      adapter: mysql2
+      username: root
+      password:
+      host: localhost
+      port: 3306
+      encoding: utf8
+      database:
+      database: redis_shard1_test
+    redis_shard_2:
+      adapter: mysql2
+      username: root
+      password:
+      host: localhost
+      port: 3306
+      encoding: utf8
+      database: redis_shard2_test

--- a/spec/config/turntable.yml
+++ b/spec/config/turntable.yml
@@ -15,3 +15,15 @@ test:
           less_than: 80000
         - connection: user_shard_3
           less_than: 10000000
+    friend_cluster:
+      algorithm: modulo
+      seq:
+        seq_type: redis
+        connection: redis_sequencer
+      shards:
+        - connection: redis_shard_1
+        - connection: redis_shard_2
+  redis:
+    redis_sequencer:
+      host: localhost
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,5 +24,3 @@ RSpec.configure do |config|
   config.before(:each) do
   end
 end
-
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,5 @@ RSpec.configure do |config|
   config.before(:each) do
   end
 end
+
+

--- a/spec/test_models.rb
+++ b/spec/test_models.rb
@@ -25,3 +25,9 @@ class CardsUser < ActiveRecord::Base
   belongs_to :user
   belongs_to :card
 end
+
+class Friend < ActiveRecord::Base
+  turntable :friend_cluster, :id
+  sequencer
+end
+

--- a/spec/turntable_helper.rb
+++ b/spec/turntable_helper.rb
@@ -27,3 +27,15 @@ end
 def migrate(version)
   ActiveRecord::Migrator.run(:up, MIGRATIONS_ROOT, version)
 end
+
+module ActiveRecord::Turntable
+  module TestRackupFramework
+    def self.env
+      "test"
+    end
+    def self.root
+      File.dirname(File.dirname(__FILE__))
+    end
+  end
+  RackupFramework = TestRackupFramework
+end


### PR DESCRIPTION
redisを利用したsequencerを追加します

## 修正点/特記事項
- redisを利用したsequencerの追加
- シーケンス番号を保持するキーの存在チェックを行うためにlua scriptを利用
- redis.getを利用すると文字列として返却されるので数値に変換して返却
- 一部動作しなかったspecの修正


