### PR TITLE
Use first shard as PoolProxy spec

### DIFF
--- a/lib/active_record/turntable/connection_proxy.rb
+++ b/lib/active_record/turntable/connection_proxy.rb
@@ -237,7 +237,7 @@ module ActiveRecord::Turntable
     end
 
     def spec
-      @spec ||= master.connection_pool.spec
+      @spec ||= shards.values.first.connection_pool.spec
     end
   end
 end


### PR DESCRIPTION
master_shard is usually identical across clusters. Therefore, it doesn't make sense to use master_shard's spec as the cluster's one. On the other hand, shards usually are not.

see https://github.com/monsterstrike/activerecord-turntable/blob/tiepadrino/lib/active_record/turntable/base.rb#L66