### PR TITLE
「MMG」Fix turntable for AR 4.0.13

### DIFF
--- a/lib/active_record/turntable/active_record_ext/fixtures.rb
+++ b/lib/active_record/turntable/active_record_ext/fixtures.rb
@@ -3,7 +3,7 @@
 #
 require 'active_record/fixtures'
 module ActiveRecord
-  class Fixtures
+  class FixtureSet
     def self.create_fixtures(fixtures_directory, table_names, class_names = {})
       table_names = [table_names].flatten.map { |n| n.to_s }
       table_names.each { |n|

--- a/lib/active_record/turntable/base.rb
+++ b/lib/active_record/turntable/base.rb
@@ -62,7 +62,11 @@ module ActiveRecord::Turntable
       def turntable_replace_connection_pool
         ch = connection_handler
         cp = turntable_cluster.connection_proxy
-        if ActiveRecord::VERSION::STRING >= '3.2.0'
+        if ActiveRecord::VERSION::STRING >= '4.0.0'
+          proxy = PoolProxy.new(cp)
+          ch.send(:owner_to_pool)[name] = proxy
+          ch.send(:class_to_pool)[name] = proxy
+        elsif ActiveRecord::VERSION::STRING >= '3.2.0'
           ch.connection_pools[cp.spec] = PoolProxy.new(cp)
           ch.instance_variable_get(:@class_to_pool)[name] = ch.connection_pools[cp.spec]
         else
@@ -77,7 +81,7 @@ module ActiveRecord::Turntable
           raise "Please install the #{config['adapter']} adapter: `gem install activerecord-#{config['adapter']}-adapter` (#{e})"
         end
         adapter_method = "#{config['adapter']}_connection"
-        ActiveRecord::Base::ConnectionSpecification.new(config, adapter_method)
+        ActiveRecord::ConnectionAdapters::ConnectionSpecification.new(config, adapter_method)
       end
 
       def clear_all_connections!

--- a/lib/active_record/turntable/shard.rb
+++ b/lib/active_record/turntable/shard.rb
@@ -42,7 +42,7 @@ module ActiveRecord::Turntable
         raise "Please install the #{adapter} adapter: `gem install activerecord-#{adapter}-adapter` (#{e})"
       end
       adapter_method = "#{adapter}_connection"
-      ActiveRecord::Base::ConnectionSpecification.new(config, adapter_method)
+      ActiveRecord::ConnectionAdapters::ConnectionSpecification.new(config, adapter_method)
     end
   end
 end


### PR DESCRIPTION
AR 4.0.13の状態でturntableが動く風にしてみた

* Fixturesは名前4.0.0からFixtureSetに変更
* ConnectionSpecificationのnamespaceはBaseからConnectionAdaptersに

ここからが問題

* 4系はclass_to_poolなどの構造が変わった、pidがまずキーとして入るようになった、これは不安要素。turntable_replace_connection_poolはここの独自だからなんとかするしかないか？
* 独自差分はprocessごとにconnectionを再接続するのちらほらですが、4系はそもそも不要

上記鑑み1.xのままはやっぱ不安ですね
