### PR TITLE
[no merge] patch to stable-2-x

### DIFF
--- a/lib/active_record/turntable.rb
+++ b/lib/active_record/turntable.rb
@@ -50,13 +50,16 @@ module ActiveRecord::Turntable
     include Base
   end
 
+  RackupFramework = Rails   if defined?(Rails);
+  RackupFramework = Padrino if defined?(Padrino);
+
   module ClassMethods
     DEFAULT_PATH = File.dirname(File.dirname(__FILE__))
 
     def turntable_config_file
       @@turntable_config_file ||=
-        File.join(defined?(::Rails) ?
-                   ::Rails.root.to_s : DEFAULT_PATH, 'config/turntable.yml')
+        File.join(defined?(ActiveRecord::Turntable::RackupFramework) ?
+                  ActiveRecord::Turntable::RackupFramework.root.to_s : DEFAULT_PATH, 'config/turntable.yml')
     end
 
     def turntable_config_file=(filename)

--- a/lib/active_record/turntable.rb
+++ b/lib/active_record/turntable.rb
@@ -69,4 +69,5 @@ module ActiveRecord::Turntable
   end
 
   require "active_record/turntable/railtie" if defined?(Rails)
+  require "active_record/turntable/padrinotie" if defined?(Padrino)
 end

--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -18,7 +18,7 @@ module ActiveRecord::Turntable
                                    :turntable_shard_name => turntable_shard_name) { yield }
         rescue Exception => e
           message = "#{e.class.name}: #{e.message}: #{sql} : #{turntable_shard_name}"
-          @logger.error message if @logger
+          @logger.debug message if @logger
           exception = translate_exception(e, message)
           exception.set_backtrace e.backtrace
           raise exception

--- a/lib/active_record/turntable/active_record_ext/database_tasks.rb
+++ b/lib/active_record/turntable/active_record_ext/database_tasks.rb
@@ -3,6 +3,10 @@ require 'active_record/tasks/database_tasks'
 module ActiveRecord
   module Tasks
     module DatabaseTasks
+      def env
+        @env ||= ActiveRecord::Turntable::RackupFramework.env
+      end
+
       def create_all_turntable_cluster
         each_local_turntable_cluster_configuration { |name, configuration|
           puts "[turntable] *** executing to database: #{configuration['database']}"

--- a/lib/active_record/turntable/base.rb
+++ b/lib/active_record/turntable/base.rb
@@ -41,7 +41,6 @@ module ActiveRecord::Turntable
         turntable_replace_connection_pool
       end
 
-
       def turntable_replace_connection_pool
         ch = connection_handler
         cp = ConnectionProxy.new(self, turntable_cluster)

--- a/lib/active_record/turntable/cluster_helper_methods.rb
+++ b/lib/active_record/turntable/cluster_helper_methods.rb
@@ -30,7 +30,7 @@ module ActiveRecord::Turntable
       end
 
       def force_connect_all_shards!
-        conf = configurations[Rails.env]
+        conf = configurations[ActiveRecord::Turntable::RackupFramework.env]
         shards = {}
         shards = shards.merge(conf["shards"]) if conf["shards"]
         shards = shards.merge(conf["seq"]) if conf["seq"]

--- a/lib/active_record/turntable/config.rb
+++ b/lib/active_record/turntable/config.rb
@@ -14,7 +14,7 @@ module ActiveRecord::Turntable
       @config[key]
     end
 
-    def self.load!(config_file = ActiveRecord::Base.turntable_config_file, env = (defined?(Rails) ? Rails.env : 'development'))
+    def self.load!(config_file = ActiveRecord::Base.turntable_config_file, env = (defined?(ActiveRecord::Turntable::RackupFramework) ? ActiveRecord::Turntable::RackupFramework.env : 'development')) # FIXME
       instance.load!(config_file, env)
     end
 

--- a/lib/active_record/turntable/connection_proxy.rb
+++ b/lib/active_record/turntable/connection_proxy.rb
@@ -234,7 +234,7 @@ module ActiveRecord::Turntable
     end
 
     def spec
-      @spec ||= master.connection_pool.spec
+      @spec ||= shards.values.first.connection_pool.spec
     end
 
     private

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -37,7 +37,8 @@ module ActiveRecord::Turntable::Migration
   end
 
   def target_shard?(shard_name)
-    target_shards.blank? or target_shards.include?(shard_name)
+    return false if shard_name.present? && target_shards.blank?
+    shard_name.nil? or target_shards.blank? or target_shards.include?(shard_name)
   end
 
   def announce_with_turntable(message)

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -1,3 +1,5 @@
+require 'active_record/turntable/active_record_ext/database_tasks'
+
 module ActiveRecord::Turntable::Migration
   extend ActiveSupport::Concern
 

--- a/lib/active_record/turntable/mixer.rb
+++ b/lib/active_record/turntable/mixer.rb
@@ -144,7 +144,7 @@ module ActiveRecord::Turntable
                                                   build_shards_with_same_query(@proxy.shards.values, query),
                                                   method, query, *args, &block
                                                   )
-      elsif tree.group_by or tree.order_by or tree.limit.try(:value).to_i > 0
+      elsif @proxy.current_shard.blank? and (tree.group_by or tree.order_by or tree.limit.try(:value).to_i > 0)
         raise CannotSpecifyShardError, "cannot specify shard for query: #{tree.to_sql}"
       elsif shard_keys.present?
         if SQLTree::Node::SelectDeclaration === tree.select.first and

--- a/lib/active_record/turntable/padrinotie.rb
+++ b/lib/active_record/turntable/padrinotie.rb
@@ -1,0 +1,17 @@
+module ActiveRecord::Turntable
+  class Padrinotie
+    Padrino::Tasks.files << File.dirname(__FILE__) + "/padrinoties/databases.rb"
+
+    # # rails loading hook
+    # ActiveSupport.on_load(:before_initialize) do
+    #   ActiveSupport.on_load(:active_record) do
+    #     ActiveRecord::Base.send(:include, ActiveRecord::Turntable)
+    #   end
+    # end
+
+    # # Swap QueryCache Middleware
+    # initializer "turntable.swap_query_cache_middleware" do |app|
+    #   app.middleware.swap ActiveRecord::QueryCache, ActiveRecord::Turntable::Rack::QueryCache
+    # end
+  end
+end

--- a/lib/active_record/turntable/padrinotie.rb
+++ b/lib/active_record/turntable/padrinotie.rb
@@ -7,7 +7,6 @@ module ActiveRecord::Turntable
     Padrino.before_load do
       ActiveRecord::Base.send(:include, ActiveRecord::Turntable)
 
-      Padrino::Generators.load_components!
       require 'generators/padrino/turntable/install_generators'
     end
     # # Swap QueryCache Middleware

--- a/lib/active_record/turntable/padrinotie.rb
+++ b/lib/active_record/turntable/padrinotie.rb
@@ -1,14 +1,15 @@
+# -*- coding: utf-8 -*-
 module ActiveRecord::Turntable
   class Padrinotie
     Padrino::Tasks.files << File.dirname(__FILE__) + "/padrinoties/databases.rb"
 
-    # # rails loading hook
-    # ActiveSupport.on_load(:before_initialize) do
-    #   ActiveSupport.on_load(:active_record) do
-    #     ActiveRecord::Base.send(:include, ActiveRecord::Turntable)
-    #   end
-    # end
+    # padrino loading hook
+    Padrino.before_load do
+      ActiveRecord::Base.send(:include, ActiveRecord::Turntable)
 
+      Padrino::Generators.load_components!
+      require 'generators/padrino/turntable/install_generators'
+    end
     # # Swap QueryCache Middleware
     # initializer "turntable.swap_query_cache_middleware" do |app|
     #   app.middleware.swap ActiveRecord::QueryCache, ActiveRecord::Turntable::Rack::QueryCache

--- a/lib/active_record/turntable/padrinoties/databases.rb
+++ b/lib/active_record/turntable/padrinoties/databases.rb
@@ -1,0 +1,204 @@
+require 'active_record/turntable'
+ActiveRecord::SchemaDumper.send(:include, ActiveRecord::Turntable::ActiveRecordExt::SchemaDumper)
+
+db_namespace = namespace :ar do
+  task :create do
+    if Padrino.env == "test" && ActiveRecord::Base.configurations["test"]["shards"]
+      dbs = ActiveRecord::Base.configurations["test"]["shards"].values
+      dbs += ActiveRecord::Base.configurations["test"]["seq"].values if ActiveRecord::Base.configurations["test"]["seq"]
+      dbs.each do |shard_config|
+        create_database(shard_config)
+      end
+    end
+    if shard_configs = ActiveRecord::Base.configurations[Padrino.env || 'development']["shards"]
+      dbs = shard_configs.values
+      dbs += ActiveRecord::Base.configurations[Padrino.env || 'development']["seq"].values if ActiveRecord::Base.configurations[Padrino.env || 'development']["seq"]
+      dbs.each do |shard_config|
+        create_database(shard_config)
+      end
+    end
+    config = ActiveRecord::Base.configurations[Padrino.env || 'development']
+    ActiveRecord::Base.establish_connection(config)
+  end
+
+  task :drop do
+    config = ActiveRecord::Base.configurations[Padrino.env || 'development']
+    shard_configs = config["shards"]
+    if shard_configs
+      dbs = shard_configs.values
+      dbs += ActiveRecord::Base.configurations[Padrino.env || 'development']["seq"].values if ActiveRecord::Base.configurations[Padrino.env || 'development']["seq"]
+      dbs.each do |shard_config|
+        begin
+          drop_database(shard_config)
+        rescue Exception => e
+          $stderr.puts "Couldn't drop #{ config['database']} : #{e.inspect}"
+        end
+      end
+    end
+    ActiveRecord::Base.establish_connection(config)
+  end
+
+  namespace :schema do
+    task :dump do
+      require 'active_record/schema_dumper'
+      config = ActiveRecord::Base.configurations[Padrino.env]
+      shard_configs = config["shards"]
+      shard_configs.merge!(config["seq"]) if config["seq"]
+      if shard_configs
+        shard_configs.each do |name, config|
+          filename = ENV['SCHEMA'] ||  Padrino.root("db", "schema-#{name}.rb")
+          File.open(filename, "w:utf-8") do |file|
+            ActiveRecord::Base.establish_connection(config)
+            ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+          end
+        end
+      end
+      ActiveRecord::Base.establish_connection(config)
+      db_namespace['schema:dump'].reenable
+    end
+
+    desc 'Load a schema.rb file into the database'
+    task :load => :environment do
+      config = ActiveRecord::Base.configurations[Padrino.env]
+      shard_configs = config["shards"]
+      shard_configs.merge!(config["seq"]) if config["seq"]
+      if shard_configs
+        shard_configs.each do |name, config|
+          ActiveRecord::Base.establish_connection(config)
+          file = ENV['SCHEMA'] || Padrino.root("db", "schema-#{name}.rb")
+          if File.exists?(file)
+            load(file)
+          else
+            abort %{#{file} doesn't exist yet. Run "rake db:migrate" to create it then try again. If you do not intend to use a database, you should instead alter #{Padrino.root}/config/application.rb to limit the frameworks that will be loaded'}
+          end
+        end
+      end
+      ActiveRecord::Base.establish_connection(config)
+    end
+  end
+
+  namespace :structure do
+    desc 'Dump the database structure to an SQL file'
+    task :dump => :environment do
+      config = ActiveRecord::Base.configurations[Padrino.env]
+      shard_configs = config["shards"]
+      shard_configs.merge!(config["seq"]) if config["seq"]
+      if shard_configs
+        shard_configs.each do |name, config|
+          case config['adapter']
+          when /mysql/, 'oci', 'oracle'
+            ActiveRecord::Base.establish_connection(config)
+            File.open(Padrino.root("db", "#{Padrino.env}_#{name}_structure.sql"), "w+") { |f| f << ActiveRecord::Base.connection.structure_dump }
+          when /postgresql/
+            ENV['PGHOST']     = config['host'] if config['host']
+            ENV['PGPORT']     = config["port"].to_s if config['port']
+            ENV['PGPASSWORD'] = config['password'].to_s if config['password']
+            search_path = config['schema_search_path']
+            unless search_path.blank?
+              search_path = search_path.split(",").map{|search_path| "--schema=#{search_path.strip}" }.join(" ")
+            end
+            `pg_dump -i -U "#{config['username']}" -s -x -O -f #{Padrino.root("db", "#{Padrino.env}_#{name}_structure.sql")} #{search_path} #{config['database']}`
+            raise 'Error dumping database' if $?.exitstatus == 1
+          when /sqlite/
+            dbfile = config['database'] || config['dbfile']
+            `sqlite3 #{dbfile} .schema > db/#{Padrino.env}_#{name}_structure.sql`
+          when 'sqlserver'
+            `smoscript -s #{config['host']} -d #{config['database']} -u #{config['username']} -p #{config['password']} -f #{Padrino.root("db", "#{Padrino.env}_#{name}_structure.sql")} -A -U`
+          when "firebird"
+            set_firebird_env(config)
+            db_string = firebird_db_string(config)
+            sh "isql -a #{db_string} > #{Padrino.root("db", "#{Padrino.env}_#{name}_structure.sql")}"
+          else
+            raise "Task not supported by '#{config["adapter"]}'"
+          end
+
+          if ActiveRecord::Base.connection.supports_migrations?
+            File.open(Padrino.root("db", "#{Padrino.env}_#{name}_structure.sql"), "a") { |f| f << ActiveRecord::Base.connection.dump_schema_information }
+          end
+        end
+      end
+      ActiveRecord::Base.establish_connection(config)
+    end
+  end
+
+
+  namespace :test do
+    # desc "Recreate the test databases from the development structure"
+    task :clone_structure do
+      config = ActiveRecord::Base.configurations[Padrino.env]
+      shard_configs = config["shards"]
+      shard_configs.merge!(config["seq"]) if config["seq"]
+      if shard_configs
+        shard_configs.each do |name, config|
+          case config['adapter']
+          when /mysql/
+            ActiveRecord::Base.establish_connection(config)
+            ActiveRecord::Base.connection.execute('SET foreign_key_checks = 0')
+            IO.readlines(Padrino.root("db", "#{Padrino.env}_#{name}_structure.sql")).join.split("\n\n").each do |table|
+              ActiveRecord::Base.connection.execute(table)
+            end
+          when /postgresql/
+            ENV['PGHOST']     = config['host'] if config['host']
+            ENV['PGPORT']     = config['port'].to_s if config['port']
+            ENV['PGPASSWORD'] = config['password'].to_s if config['password']
+            `psql -U "#{config['username']}" -f "#{Padrino.root("db","#{Padrino.env}#{name}_structure.sql")} #{config['database']} #{config['template']}`
+          when /sqlite/
+            dbfile = config['database'] || config['dbfile']
+            `sqlite3 #{dbfile} < "#{Padrino.root("db", "#{Padrino.env}#{name}_structure.sql")}`
+          when 'sqlserver'
+            `sqlcmd -S #{config['host']} -d #{config['database']} -U #{config['username']} -P #{config['password']} -i #{Padrino.root("db", "#{Padrino.env}#{name}_structure.sql")}`
+          when 'oci', 'oracle'
+            ActiveRecord::Base.establish_connection(config)
+            IO.readlines(Padrino.root("db", "#{Padrino.env}#{name}_structure.sql")).join.split(";\n\n").each do |ddl|
+              ActiveRecord::Base.connection.execute(ddl)
+            end
+          when 'firebird'
+            set_firebird_env(config)
+            db_string = firebird_db_string(config)
+            sh "isql -i #{Padrino.root("db","#{Padrino.env}#{name}_structure.sql")} #{db_string}"
+          else
+            raise "Task not supported by '#{config['adapter']}'"
+          end
+        end
+      end
+      ActiveRecord::Base.establish_connection(config)
+    end
+
+    # desc "Empty the test database"
+    task :purge => :environment do
+      config = ActiveRecord::Base.configurations[Padrino.env]
+      shard_configs = config["shards"]
+      shard_configs.merge!(config["seq"]) if config["seq"]
+      if shard_configs
+        shard_configs.each do |name, config|
+          case config['adapter']
+          when /mysql/
+            ActiveRecord::Base.establish_connection(config)
+            ActiveRecord::Base.connection.recreate_database(config['database'], mysql_creation_options(config))
+          when /postgresql/
+            ActiveRecord::Base.clear_active_connections!
+            drop_database(config)
+            create_database(config)
+          when /sqlite/
+            dbfile = config['database'] || config['dbfile']
+            File.delete(dbfile) if File.exist?(dbfile)
+          when 'sqlserver'
+            # TODO
+          when "oci", "oracle"
+            ActiveRecord::Base.establish_connection(config)
+            ActiveRecord::Base.connection.structure_drop.split(";\n\n").each do |ddl|
+              ActiveRecord::Base.connection.execute(ddl)
+            end
+          when 'firebird'
+            ActiveRecord::Base.establish_connection(config)
+            ActiveRecord::Base.connection.recreate_database!
+          else
+            raise "Task not supported by '#{config['adapter']}'"
+          end
+        end
+      end
+      ActiveRecord::Base.establish_connection(config)
+    end
+  end
+end
+

--- a/lib/active_record/turntable/seq_shard.rb
+++ b/lib/active_record/turntable/seq_shard.rb
@@ -12,7 +12,7 @@ module ActiveRecord::Turntable
     def retrieve_connection_pool
       ActiveRecord::Base.turntable_connections[name] ||=
         begin
-          config = ActiveRecord::Base.configurations[Rails.env]["seq"][name]
+          config = ActiveRecord::Base.configurations[ActiveRecord::Turntable::RackupFramework.env]["seq"][name]
           raise ArgumentError, "Unknown database config: #{name}, have #{ActiveRecord::Base.configurations.inspect}" unless config
           ActiveRecord::ConnectionAdapters::ConnectionPool.new(spec_for(config))
         end

--- a/lib/active_record/turntable/sequencer/mysql.rb
+++ b/lib/active_record/turntable/sequencer/mysql.rb
@@ -11,9 +11,10 @@ module ActiveRecord::Turntable
         @options = options
       end
 
-      def next_sequence_value(sequence_name)
+      # mysql だけ offset を指定できるようにします
+      def next_sequence_value(sequence_name, offset = 1)
         conn = @klass.connection.seq.connection
-        conn.execute "UPDATE #{@klass.connection.quote_table_name(sequence_name)} SET id=LAST_INSERT_ID(id+1)"
+        conn.execute "UPDATE #{@klass.connection.quote_table_name(sequence_name)} SET id=LAST_INSERT_ID(id+#{offset})"
         res = conn.execute("SELECT LAST_INSERT_ID()")
         new_id = res.first.first.to_i
         raise SequenceNotFoundError if new_id.zero?

--- a/lib/active_record/turntable/shard.rb
+++ b/lib/active_record/turntable/shard.rb
@@ -3,7 +3,7 @@ module ActiveRecord::Turntable
     module Connections; end
 
     DEFAULT_CONFIG = {
-      "connection" => (defined?(Rails) ? Rails.env : "development")
+      "connection" => (defined?(ActiveRecord::Turntable::RackupFramework) ? ActiveRecord::Turntable::RackupFramework.env : "development")
     }.with_indifferent_access
 
     attr_reader :name

--- a/lib/active_record/turntable/sql_tree_patch.rb
+++ b/lib/active_record/turntable/sql_tree_patch.rb
@@ -52,6 +52,7 @@ class SQLTree::Tokenizer
       when /\w/;           tokenize_keyword(&block)
       when OPERATOR_CHARS; tokenize_operator(&block)
       when SQLTree.identifier_quote_char; tokenize_quoted_identifier(&block)
+      when SQLTree.identifier_quote_field_char; tokenize_identifier_with_quote(&block)
       end
     end
 
@@ -72,6 +73,14 @@ class SQLTree::Tokenizer
     else
       tokenize_keyword(&block)
     end
+  end
+
+  def tokenize_identifier_with_quote(&block)
+    next_char # skip identifier_quote_field_char
+    literal = current_char
+    literal << next_char while SQLTree.identifier_quote_field_char != peek_char
+    next_char # skip identifier_quote_field_char
+    handle_token(SQLTree::Token::Identifier.new(literal), &block)
   end
 end
 

--- a/lib/generators/padrino/turntable/install_generators.rb
+++ b/lib/generators/padrino/turntable/install_generators.rb
@@ -1,7 +1,9 @@
-require 'padrino-gen'
+require 'thor/group'
 
 module Padrino
   module Generators
+    Padrino::Generators.load_components!
+
     class Turntable < Thor::Group
       Padrino::Generators.add_generator(:turntable, self)
 

--- a/lib/generators/padrino/turntable/install_generators.rb
+++ b/lib/generators/padrino/turntable/install_generators.rb
@@ -1,0 +1,29 @@
+require 'padrino-gen'
+
+module Padrino
+  module Generators
+    class Turntable < Thor::Group
+      Padrino::Generators.add_generator(:turntable, self)
+
+      def self.source_root
+        File.expand_path("../../../templates", __FILE__)
+      end
+
+      desc "Creates turntable configuration file (config/turntable.yml)"
+
+      include Thor::Actions
+      include Padrino::Generators::Actions
+      include Padrino::Generators::Components::Actions
+
+      desc "Creates turntable configuration file (config/turntable.yml)"
+
+      def self.require_arguments?
+        false
+      end
+
+      def create_turntable
+        copy_file "turntable.yml", "config/turntable.yml"
+      end
+    end
+  end
+end


### PR DESCRIPTION
exec `git cherry-pick c706d92~..2830656 `

- this diff is patch for Padrino
- reference commits for conflict
    - https://github.com/monsterstrike/activerecord-turntable/commit/3259d5ce869f25aaf8d3bc4a43ec0523cebdebfb#diff-9dd1cb1f86f08b87ff64f53baa7ea1f9
    - https://github.com/monsterstrike/activerecord-turntable/commit/5a189c7d6a055fe443c3c2afd6a2cf8b65cc1595#diff-1b892354e5f352d814c37ce8845899ba
    - https://github.com/monsterstrike/activerecord-turntable/commit/401e580fbc9714801a133cc38b82411d8d7f6e4b#diff-a510537b0a07efb215b996707da47c1b
    - https://github.com/monsterstrike/activerecord-turntable/commit/fc4d8b617593000f03020397883de1ffb25e037f#diff-62cc6166823bc5b7dc9c31a39c6590cf
- modulo algorithm is merge to upstream #26

and

- add require without rails auto load bee9980
- use RackupEnv for DatabaseTasks default env 6172acf
- fix `target_shard?` 9694b3b
    - don't migrate no cluster table to shard
    - migrate cluster table to master (for cache schema)
- cherry pick https://github.com/monsterstrike/activerecord-turntable/pull/3
- fix SQL parser for backquote on MySQL 5e90d11
- cherry pick https://github.com/hanabokuro/activerecord-turntable/pull/1