### PR TITLE
Fix boot rspec. Change factory_bot v5 syntax.

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     trait :with_user_items do
       transient do
-        user_items_count 10
+        user_items_count { 10 }
       end
 
       after(:build) do |user, evaluator|
@@ -30,8 +30,8 @@ FactoryBot.define do
     end
 
     trait :created_yesterday do
-      created_at 1.day.ago
-      updated_at 1.day.ago
+      created_at { 1.day.ago }
+      updated_at { 1.day.ago }
     end
   end
 


### PR DESCRIPTION
Fix boot rspec. Change factory_bot v5 syntax.

factory_bot の v5以上のsyntaxに修正して、rspecが動作するようにupstreamからcommitを取りこんだ。

## before

```ruby
~/src/github.com/monsterstrike/activerecord-turntable patch-ms-to-stable*
❯ asdf exec bundle exec rspec ./spec
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options:
  include {:focus=>true}
  exclude {:with_katsubushi=>true}

All examples were filtered out; ignoring {:focus=>true}

An error occurred in a `before(:suite)` hook.
Failure/Error: user_items_count 10

NoMethodError:
  undefined method 'user_items_count' in 'with_user_items' factory
  Did you mean? 'user_items_count { 10 }'
# ./spec/factories/users.rb:12:in `block (4 levels) in <top (required)>'
# ./spec/factories/users.rb:11:in `block (3 levels) in <top (required)>'
# ./spec/factories/users.rb:10:in `block (2 levels) in <top (required)>'
# ./spec/factories/users.rb:2:in `block in <top (required)>'
# ./spec/factories/users.rb:1:in `<top (required)>'
# ./spec/spec_helper.rb:50:in `block (2 levels) in <top (required)>'

Finished in 0.03565 seconds (files took 1.71 seconds to load)
0 examples, 0 failures
```

## after

```ruby
❯ asdf exec bundle exec rspec ./spec
warning: parser/current is loading parser/ruby25, which recognizes 2.5.9-compliant syntax, but you are running 2.5.1.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
/home/hirocaster/src/github.com/monsterstrike/activerecord-turntable/vendor/bundle/gems/pry-byebug-3.8.0/lib/pry-byebug/control_d_handler.rb:5: warning: control_d_handler's arity of 2 parameters was deprecated (eval_string, pry_instance). Now it gets passed just 1 parameter (pry_instance)
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options:
  include {:focus=>true}
  exclude {:with_katsubushi=>true}

All examples were filtered out; ignoring {:focus=>true}

ActiveRecord::FinderMethods
  .find
    pass an ID that exists
      should eq #<User id: 10, nickname: nil, thumbnail_url: nil, blob: nil, joined_at: nil, deleted_at: nil, created_at: "2023-01-13 07:29:14", updated_at: "2023-01-13 07:29:14">
    pass an ID that doesn't exist
      should raise ActiveRecord::RecordNotFound
(省略)
```