### PR TITLE
Support activerecord import v1.0.7 and factory bot v5

### DIFF
--- a/lib/active_record/turntable/mixer.rb
+++ b/lib/active_record/turntable/mixer.rb
@@ -37,6 +37,17 @@ module ActiveRecord::Turntable
 
       case tree
       when SQLTree::Node::SelectQuery
+
+        # Support activerecord-import version ">=1.0.7"
+        # ref: https://github.com/zdennis/activerecord-import/pull/706
+        # SHOW VARIABLES LIKE 'name'
+        if tree.where == nil && tree.from == nil && tree.to_sql.include?("max_allowed_packet")
+          # send to default shard
+          return Fader::SpecifiedShard.new(@proxy,
+                                           { @proxy.default_shard => query },
+                                           method, query, *args, &block)
+        end
+
         build_select_fader(tree, method, query, *args, &block)
       when SQLTree::Node::UpdateQuery, SQLTree::Node::DeleteQuery
         build_update_fader(tree, method, query, *args, &block)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     trait :with_user_items do
       transient do
-        user_items_count 10
+        user_items_count { 10 }
       end
 
       after(:build) do |user, evaluator|
@@ -30,8 +30,8 @@ FactoryBot.define do
     end
 
     trait :created_yesterday do
-      created_at 1.day.ago
-      updated_at 1.day.ago
+      created_at { 1.day.ago }
+      updated_at { 1.day.ago }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,15 @@ require "webmock/rspec"
 require "timecop"
 require "pry-byebug"
 require "factory_bot"
-require "faker"
+# Change use_parent_strategy, factory_bot v5
+# https://github.com/thoughtbot/factory_bot/commit/d0208eda9c65cbc476a02d2f7503234195610005
+factory_bot_current_version = Gem::Version.create(FactoryBot::VERSION)
+factory_bot_v5_version = Gem::Version.create("5.0.0")
+if factory_bot_current_version >= factory_bot_v5_version
+  FactoryBot.use_parent_strategy = false
+end
 
+require "faker"
 require "coveralls"
 Coveralls.wear!
 


### PR DESCRIPTION
## Support activerecord-import v1.0.7

Change fetch `max_allowed_packet` by MySQL in activerecord-import v1.0.7.
https://github.com/zdennis/activerecord-import/commit/04b3ab3d002367b1fc238e5a214517f426744a4c

So, faild `activerecord_import_ext_spec.rb`.

## Support factory_bot v5.

Change use_parent_strategy,
https://github.com/thoughtbot/factory_bot/commit/d0208eda9c65cbc476a02d2f7503234195610005

Add config for factory_bot.
`FactoryBot.use_parent_strategy = false`

So, Compatible strategy factory_bot v4.


## Before activerecord-import v1.0.6


SQL(`SHOW VARIABLES like 'max_allowed_packet'`) log

```ruby
[1] pry(#<RSpec::ExampleGroups::ActiveRecordTurntableActiveRecordExtActiverecordImportExt::WithSequencerEnabledModel>)> UserItem.import(rows)

(...)

D, [2023-01-13T11:45:53.281663 #12849] DEBUG -- :    (3.3ms) [Shard: master]  SHOW VARIABLES like 'max_allowed_packet'
(..)

=> #<struct ActiveRecord::Import::Result failed_instances=[], num_inserts=1, ids=[], results=[]>
```

```ruby
❯ asdf exec bundle exec rspec ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options:
  include {:focus=>true}
  exclude {:with_katsubushi=>true}

All examples were filtered out; ignoring {:focus=>true}

ActiveRecord::Turntable::ActiveRecordExt::ActiverecordImportExt
  With sequencer enabled model
    should not raise Exception (FAILED - 1)
    creates one record on shard_1 (FAILED - 2)
    creates one record on shard_2 (FAILED - 3)

Failures:

  1) ActiveRecord::Turntable::ActiveRecordExt::ActiverecordImportExt With sequencer enabled model should not raise Exception
     Failure/Error: it { is_expected.not_to raise_error }

       expected no Exception, got #<NoMethodError: undefined method `size' for nil:NilClass> with backtrace:
         # ./lib/active_record/turntable/mixer.rb:129:in `build_select_fader'
         # ./lib/active_record/turntable/mixer.rb:40:in `build_fader'
         # ./lib/active_record/turntable/connection_proxy.rb:93:in `method_missing'
         # ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:6:in `block (4 levels) in <top (required)>'
         # ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:15:in `block (3 levels) in <top (required)>'
     # ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:15:in `block (3 levels) in <top (required)>'

  2) ActiveRecord::Turntable::ActiveRecordExt::ActiverecordImportExt With sequencer enabled model creates one record on shard_1
     Failure/Error:
       shard_keys = if !tree.where && tree.from.size == 1 && SQLTree::Node::SubQuery === tree.from.first.table_reference.table
                      find_shard_keys(tree.from.first.table_reference.table.where,
                                      @proxy.klass.table_name,
                                      @proxy.klass.turntable_shard_key.to_s)
                    else
                      find_shard_keys(tree.where,
                                      @proxy.klass.table_name,
                                      @proxy.klass.turntable_shard_key.to_s)

     NoMethodError:
       undefined method `size' for nil:NilClass
     # ./lib/active_record/turntable/mixer.rb:129:in `build_select_fader'
     # ./lib/active_record/turntable/mixer.rb:40:in `build_fader'
     # ./lib/active_record/turntable/connection_proxy.rb:93:in `method_missing'
     # ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:6:in `block (4 levels) in <top (required)>'
     # ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:17:in `block (3 levels) in <top (required)>'

  3) ActiveRecord::Turntable::ActiveRecordExt::ActiverecordImportExt With sequencer enabled model creates one record on shard_2
     Failure/Error:
       shard_keys = if !tree.where && tree.from.size == 1 && SQLTree::Node::SubQuery === tree.from.first.table_reference.table
                      find_shard_keys(tree.from.first.table_reference.table.where,
                                      @proxy.klass.table_name,
                                      @proxy.klass.turntable_shard_key.to_s)
                    else
                      find_shard_keys(tree.where,
                                      @proxy.klass.table_name,
                                      @proxy.klass.turntable_shard_key.to_s)

     NoMethodError:
       undefined method `size' for nil:NilClass
     # ./lib/active_record/turntable/mixer.rb:129:in `build_select_fader'
     # ./lib/active_record/turntable/mixer.rb:40:in `build_fader'
     # ./lib/active_record/turntable/connection_proxy.rb:93:in `method_missing'
     # ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:6:in `block (4 levels) in <top (required)>'
     # ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:23:in `block (3 levels) in <top (required)>'

Finished in 1.36 seconds (files took 1.69 seconds to load)
3 examples, 3 failures

Failed examples:

rspec ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:15 # ActiveRecord::Turntable::ActiveRecordExt::ActiverecordImportExt With sequencer enabled model should not raise Exception
rspec ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:16 # ActiveRecord::Turntable::ActiveRecordExt::ActiverecordImportExt With sequencer enabled model creates one record on shard_1
rspec ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb:22 # ActiveRecord::Turntable::ActiveRecordExt::ActiverecordImportExt With sequencer enabled model creates one record on shard_2
```

## After activerecord-import v1.0.7

SQL(`SELECT @@max_allowed_packet`) log.
Support `SELECT @@max_allowed_packet`.

```ruby
[1] pry(#<RSpec::ExampleGroups::ActiveRecordTurntableActiveRecordExtActiverecordImportExt::WithSequencerEnabledModel>)> UserItem.import(rows)

(...)

D, [2023-01-13T11:53:46.577899 #13976] DEBUG -- : [ActiveRecord::Turntable] Sending method: execute, sql: SELECT @@max_allowed_packet, shards: ["master"]

(...)

=> #<struct ActiveRecord::Import::Result failed_instances=[], num_inserts=1, ids=[], results=[]>
```

Fix spec `activerecord_import_ext_spec.rb`

```ruby
~/src/github.com/monsterstrike/activerecord-turntable support-activerecord-import-v1.0.7*
❯ asdf exec bundle exec rspec ./spec/active_record/turntable/active_record_ext/activerecord_import_ext_spec.rb
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options:
  include {:focus=>true}
  exclude {:with_katsubushi=>true}

All examples were filtered out; ignoring {:focus=>true}

ActiveRecord::Turntable::ActiveRecordExt::ActiverecordImportExt
  With sequencer enabled model
    should not raise Exception
    creates one record on shard_1
    creates one record on shard_2

Finished in 1.38 seconds (files took 1.61 seconds to load)
3 examples, 0 failures
```

All spec.

```
❯ asdf exec bundle exec rspec ./spec/

...

Finished in 16.83 seconds (files took 1.71 seconds to load)
243 examples, 2 failures, 2 pending

Failed examples:

rspec ./spec/active_record/turntable/configuration_methods_spec.rb:15 # ActiveRecord::Turntable::ConfigurationMethods#turntable_configuration_file returns Rails.root/config/turntable.yml default
rspec ./spec/active_record/turntable/migration_spec.rb:15 # ActiveRecord::Turntable::Migration.target_shards With clusters definitions should eq [#<ActiveRecord::Turntable::Shard:0x0000562cd6262f88 @cluster=#<ActiveRecord::Turntable::Cluster:0x00... @slaves=[]>], @connection_klass=ActiveRecord::Turntable::Shard::Connections::UserShard3(abstract)>]
```
