### PR TITLE
[Don't merge] Fix configuration methods spec

### DIFF
--- a/lib/active_record/turntable/configuration_methods.rb
+++ b/lib/active_record/turntable/configuration_methods.rb
@@ -1,7 +1,4 @@
 module ActiveRecord::Turntable
-  RackupFramework = Rails   if defined?(Rails);
-  RackupFramework = Padrino if defined?(Padrino);
-
   module ConfigurationMethods
     DEFAULT_PATH = File.dirname(File.dirname(__FILE__))
 
@@ -18,7 +15,15 @@ module ActiveRecord::Turntable
     deprecate "turntable_config_file=": "use turntable_configuration_file= instead", deprecator: ActiveRecord::Turntable::Deprecation.instance
 
     def turntable_app_root_path
-      defined?(ActiveRecord::Turntable::RackupFramework) ? ActiveRecord::Turntable::RackupFramework.root.to_s : DEFAULT_PATH
+      if defined?(::Padrino.root)
+        return ::Padrino.root.to_s
+      end
+
+      if defined?(::Rails.root)
+        return ::Rails.root.to_s
+      end
+
+      DEFAULT_PATH
     end
 
     def turntable_config

--- a/lib/active_record/turntable/mixer.rb
+++ b/lib/active_record/turntable/mixer.rb
@@ -37,6 +37,17 @@ module ActiveRecord::Turntable
 
       case tree
       when SQLTree::Node::SelectQuery
+
+        # Support activerecord-import version ">=1.0.7"
+        # ref: https://github.com/zdennis/activerecord-import/pull/706
+        # SHOW VARIABLES LIKE 'name'
+        if tree.where == nil && tree.from == nil && tree.to_sql.include?("max_allowed_packet")
+          # send to default shard
+          return Fader::SpecifiedShard.new(@proxy,
+                                           { @proxy.default_shard => query },
+                                           method, query, *args, &block)
+        end
+
         build_select_fader(tree, method, query, *args, &block)
       when SQLTree::Node::UpdateQuery, SQLTree::Node::DeleteQuery
         build_update_fader(tree, method, query, *args, &block)

--- a/spec/active_record/turntable/configuration_methods_spec.rb
+++ b/spec/active_record/turntable/configuration_methods_spec.rb
@@ -18,6 +18,16 @@ describe ActiveRecord::Turntable::ConfigurationMethods do
       ActiveRecord::Base.turntable_configuration_file = nil
       is_expected.to eq(File.join(rails_root, "config/turntable.yml"))
     end
+
+    let(:padrino_root) { "/path/to/padrino_root" }
+
+    it "returns Padrino.root/config/turntable.yml default" do
+      stub_const("Padrino", Class.new)
+      allow(Padrino).to receive(:root) { padrino_root }
+      ActiveRecord::Base.turntable_configuration_file = nil
+      is_expected.to eq(File.join(padrino_root, "config/turntable.yml"))
+    end
+
   end
 
   context "#turntable_configuration" do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     trait :with_user_items do
       transient do
-        user_items_count 10
+        user_items_count { 10 }
       end
 
       after(:build) do |user, evaluator|
@@ -30,8 +30,8 @@ FactoryBot.define do
     end
 
     trait :created_yesterday do
-      created_at 1.day.ago
-      updated_at 1.day.ago
+      created_at { 1.day.ago }
+      updated_at { 1.day.ago }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,15 @@ require "webmock/rspec"
 require "timecop"
 require "pry-byebug"
 require "factory_bot"
-require "faker"
+# Change use_parent_strategy, factory_bot v5
+# https://github.com/thoughtbot/factory_bot/commit/d0208eda9c65cbc476a02d2f7503234195610005
+factory_bot_current_version = Gem::Version.create(FactoryBot::VERSION)
+factory_bot_v5_version = Gem::Version.create("5.0.0")
+if factory_bot_current_version >= factory_bot_v5_version
+  FactoryBot.use_parent_strategy = false
+end
 
+require "faker"
 require "coveralls"
 Coveralls.wear!
 


### PR DESCRIPTION
Fix `configuration_methods_spec.rb`

## Before

```ruby
❯ asdf exec bundle exec rspec ./spec/active_record/turntable/configuration_methods_spec.rb --fail-fast
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options:
  include {:focus=>true}
  exclude {:with_katsubushi=>true}

All examples were filtered out; ignoring {:focus=>true}

ActiveRecord::Turntable::ConfigurationMethods
  #turntable_configuration_file
    returns Rails.root/config/turntable.yml default (FAILED - 1)

Failures:

  1) ActiveRecord::Turntable::ConfigurationMethods#turntable_configuration_file returns Rails.root/config/turntable.yml default
     Failure/Error: is_expected.to eq(File.join(rails_root, "config/turntable.yml"))

       expected: "/path/to/rails_root/config/turntable.yml"
            got: "/config/turntable.yml"

       (compared using ==)
     # ./spec/active_record/turntable/configuration_methods_spec.rb:19:in `block (3 levels) in <top (required)>'
     # ./spec/active_record/turntable/configuration_methods_spec.rb:7:in `block (3 levels) in <top (required)>'

Finished in 0.13813 seconds (files took 1.62 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/active_record/turntable/configuration_methods_spec.rb:15 # ActiveRecord::Turntable::ConfigurationMethods#turntable_configuration_file returns Rails.root/config/turntable.yml default
```

## After

```ruby
❯ asdf exec bundle exec rspec ./spec/active_record/turntable/configuration_methods_spec.rb --fail-fast
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options:
  include {:focus=>true}
  exclude {:with_katsubushi=>true}

All examples were filtered out; ignoring {:focus=>true}

ActiveRecord::Turntable::ConfigurationMethods
  #turntable_configuration_file
    returns Rails.root/config/turntable.yml default
    returns Padrino.root/config/turntable.yml default
  #turntable_configuration
    should be an instance of ActiveRecord::Turntable::Configuration

Finished in 0.16697 seconds (files took 1.58 seconds to load)
3 examples, 0 failures
```
