### PR TITLE
Configration methods support Padrino

### DIFF
--- a/lib/active_record/turntable/mixer.rb
+++ b/lib/active_record/turntable/mixer.rb
@@ -37,6 +37,17 @@ module ActiveRecord::Turntable
 
       case tree
       when SQLTree::Node::SelectQuery
+
+        # Support activerecord-import version ">=1.0.7"
+        # ref: https://github.com/zdennis/activerecord-import/pull/706
+        # SHOW VARIABLES LIKE 'name'
+        if tree.where == nil && tree.from == nil && tree.to_sql.include?("max_allowed_packet")
+          # send to default shard
+          return Fader::SpecifiedShard.new(@proxy,
+                                           { @proxy.default_shard => query },
+                                           method, query, *args, &block)
+        end
+
         build_select_fader(tree, method, query, *args, &block)
       when SQLTree::Node::UpdateQuery, SQLTree::Node::DeleteQuery
         build_update_fader(tree, method, query, *args, &block)

--- a/spec/active_record/turntable/configuration_methods_spec.rb
+++ b/spec/active_record/turntable/configuration_methods_spec.rb
@@ -17,13 +17,13 @@ describe ActiveRecord::Turntable::ConfigurationMethods do
 
     subject { ActiveRecord::Base.turntable_configuration_file }
 
-    let(:rails_root) { "/path/to/rails_root" }
+    let(:rackup_framework_root) { "/path/to/rackup_framework_root" }
 
-    it "returns Rails.root/config/turntable.yml default" do
-      stub_const("Rails", Class.new)
-      allow(Rails).to receive(:root) { rails_root }
+    it "returns ActiveRecord::Turntable::RackupFramework.root/config/turntable.yml default" do
+      stub_const("ActiveRecord::Turntable::RackupFramework", Class.new)
+      allow(ActiveRecord::Turntable::RackupFramework).to receive(:root) { rackup_framework_root }
       ActiveRecord::Base.turntable_configuration_file = nil
-      is_expected.to eq(File.join(rails_root, "config/turntable.yml"))
+      is_expected.to eq(File.join(rackup_framework_root, "config/turntable.yml"))
     end
   end
 

--- a/spec/active_record/turntable/configuration_methods_spec.rb
+++ b/spec/active_record/turntable/configuration_methods_spec.rb
@@ -1,6 +1,13 @@
 require "spec_helper"
 
 describe ActiveRecord::Turntable::ConfigurationMethods do
+  context "Define ActiveRecord::Turntable::RackupFramework" do
+    subject { ActiveRecord::Turntable::RackupFramework }
+    it "Support Rails" do
+      is_expected.to eq(Rails)
+    end
+  end
+
   context "#turntable_configuration_file" do
     around do |example|
       old_conf_path = ActiveRecord::Base.turntable_configuration_file

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     trait :with_user_items do
       transient do
-        user_items_count 10
+        user_items_count { 10 }
       end
 
       after(:build) do |user, evaluator|
@@ -30,8 +30,8 @@ FactoryBot.define do
     end
 
     trait :created_yesterday do
-      created_at 1.day.ago
-      updated_at 1.day.ago
+      created_at { 1.day.ago }
+      updated_at { 1.day.ago }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,15 @@ require "webmock/rspec"
 require "timecop"
 require "pry-byebug"
 require "factory_bot"
-require "faker"
+# Change use_parent_strategy, factory_bot v5
+# https://github.com/thoughtbot/factory_bot/commit/d0208eda9c65cbc476a02d2f7503234195610005
+factory_bot_current_version = Gem::Version.create(FactoryBot::VERSION)
+factory_bot_v5_version = Gem::Version.create("5.0.0")
+if factory_bot_current_version >= factory_bot_v5_version
+  FactoryBot.use_parent_strategy = false
+end
 
+require "faker"
 require "coveralls"
 Coveralls.wear!
 


### PR DESCRIPTION
Add/Change spec for wrap `Rails` and `Padrino` class by ActiveRecord::Turntable::RackupFramework.