### PR TITLE
Disable show suffix ` - Shard:` at not using shard connection.

### DIFF
--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -33,7 +33,11 @@ module ActiveRecord::Turntable::Migration
 
   module OverrideMethods
     def announce(message)
-      super("#{message} - Shard: #{self.current_shard}")
+      if self.current_shard
+        super("#{message} - Shard: #{self.current_shard}")
+      else
+        super("#{message}")
+      end
     end
 
     def exec_migration(*args)


### PR DESCRIPTION
Example)

## Before

```ruby
❯ bundle exec padrino rake ar:migrate:up MIGRATION_VERSION=20220124123
=> Executing Rake ar:migrate:up MIGRATION_VERSION=20220124123 ...
== 20220124123 CreateStage: Switching connection to other_db - Shard:
== 20220124123 CreateStage: migrating - Shard:  =========
-- create_table(:stages, {:options=>"ENGINE=InnoDB DEFAULT CHARSET=utf8", :id=>:integer})
   -> 0.0162s
-- add_index(:stages, :stage_id, {:unique=>true})
   -> 0.0141s
== 20220124123 CreateStage: migrated (0.0306s) - Shard:

== 20220124123 CreateStage: Switching connection back - Shard:
```

## After

```ruby
❯ bundle exec padrino rake ar:migrate:up MIGRATION_VERSION=20220124123
=> Executing Rake ar:migrate:up MIGRATION_VERSION=20220124123 ...
== 20220124123 CreateStage: Switching connection to other_db
== 20220124123 CreateStage: migrating ===================
-- create_table(:stage, {:options=>"ENGINE=InnoDB DEFAULT CHARSET=utf8", :id=>:integer})
   -> 0.0160s
-- add_index(:stages, :stage_id, {:unique=>true})
   -> 0.0130s
== 20220124123 CreateStage: migrated (0.0293s) ==========

== 20220124123 CreateStage: Switching connection back ===

```