### PR TITLE
Start commits fix warnings on Ruby 2.7.x

### DIFF
--- a/lib/active_record/turntable/cluster.rb
+++ b/lib/active_record/turntable/cluster.rb
@@ -45,11 +45,11 @@ module ActiveRecord::Turntable
       end
       shard = to_shard(shards.shift)
       if shards.present?
-        shard.connection.transaction(options) do
+        shard.connection.transaction(**options) do
           shards_transaction(shards, options, true, &block)
         end
       else
-        shard.connection.transaction(options) do
+        shard.connection.transaction(**options) do
           yield
         end
       end

--- a/lib/active_record/turntable/connection_proxy.rb
+++ b/lib/active_record/turntable/connection_proxy.rb
@@ -33,7 +33,7 @@ module ActiveRecord::Turntable
 
     def transaction(options = {}, &block)
       with_master {
-        connection.transaction(options, &block)
+        connection.transaction(**options, &block)
       }
     end
 

--- a/lib/active_record/turntable/connection_proxy/mixable.rb
+++ b/lib/active_record/turntable/connection_proxy/mixable.rb
@@ -9,8 +9,8 @@ module ActiveRecord::Turntable
 
       def mixable?(method, *args)
         (method.to_s =~ METHODS_REGEXP &&
-         args.first !~ EXCLUDE_QUERY_REGEXP) ||
-          (method.to_s == "execute" && args.first =~ QUERY_REGEXP)
+         args.first.to_s !~ EXCLUDE_QUERY_REGEXP) ||
+          (method.to_s == "execute" && args.first.to_s =~ QUERY_REGEXP)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,17 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require "rubygems"
 require "bundler/setup"
 
+# https://www.ruby-lang.org/ja/news/2020/10/02/ruby-2-7-2-released/
+# Feature #17000: 2.7.2 turns off deprecation warnings by default
+# https://bugs.ruby-lang.org/issues/17000
+ruby_version = Gem::Version.create(RUBY_VERSION)
+ruby27_version = Gem::Version.create("2.7.2")
+if ruby_version >= ruby27_version
+  if ENV["WARNING"]
+    Warning[:deprecated] = true
+  end
+end
+
 require "rails"
 require "action_view"
 require "action_dispatch"


### PR DESCRIPTION
This branch is to prepare for Ruby 3.0.x by fixing warnings in Ruby 2.7.