### PR TITLE
Fix: ensure syntax for ruby 2.4

### DIFF
--- a/spec/active_record/turntable/active_record_ext/query_cache_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/query_cache_spec.rb
@@ -6,16 +6,18 @@ describe ActiveRecord::Turntable::ActiveRecordExt::QueryCache do
     executor = Class.new(ActiveSupport::Executor)
     ActiveRecord::QueryCache.install_executor_hooks executor
     lambda do |env|
-      if ActiveRecord::Turntable::Util.ar60_or_later?
-        original_handlers = ActiveRecord::Base.connection_handlers
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler, reading: ActiveRecord::ConnectionAdapters::ConnectionHandler.new }
-      end
-      executor.wrap do
-        app.call(env)
-      end
-    ensure
-      if ActiveRecord::Turntable::Util.ar60_or_later?
-        ActiveRecord::Base.connection_handlers = original_handlers
+      begin
+        if ActiveRecord::Turntable::Util.ar60_or_later?
+          original_handlers = ActiveRecord::Base.connection_handlers
+          ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler, reading: ActiveRecord::ConnectionAdapters::ConnectionHandler.new }
+        end
+        executor.wrap do
+          app.call(env)
+        end
+      ensure
+        if ActiveRecord::Turntable::Util.ar60_or_later?
+          ActiveRecord::Base.connection_handlers = original_handlers
+        end
       end
     end
   end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/12906

activerecord-turntable should be used by ruby <= 2.4.
For ruby <= 2.4, syntax error happen. Cannot remove begin in a block.
