### PR TITLE
Support Ruby3.2

### DIFF
--- a/.github/workflows/test_ruby_2_7.yml
+++ b/.github/workflows/test_ruby_2_7.yml
@@ -1,5 +1,5 @@
 name: Exec Rspec
-run-name: Matrix building for ruby 2.7 ✖️ 【rails 5.0 - 6.0】 🚀
+run-name: Matrix building for ruby 2.7 ✖️ 【rails 5.0 - 6.1】 🚀
 on: [push]
 
 jobs:

--- a/.github/workflows/test_ruby_3_0.yml
+++ b/.github/workflows/test_ruby_3_0.yml
@@ -1,5 +1,5 @@
 name: Exec Rspec
-run-name: Matrix building for ruby 3.0 ✖️ 【rails 6.0】 🚀
+run-name: Matrix building for ruby 3.0 ✖️ 【rails 6.0 - 6.1】 🚀
 on: [push]
 
 jobs:

--- a/.github/workflows/test_ruby_3_2.yml
+++ b/.github/workflows/test_ruby_3_2.yml
@@ -1,0 +1,29 @@
+name: Exec Rspec
+run-name: Matrix building for ruby 3.2 ✖️ 【rails 6.1】 🚀
+on: [push]
+
+jobs:
+  ruby_3_2:
+    strategy:
+      fail-fast: false
+      matrix:
+        arversion: ['6_1_0', '6_1_1', '6_1_2', '6_1_3', '6_1_4', '6_1_5', '6_1_6', '6_1_7']
+    runs-on: ubuntu-22.04
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails${{ matrix.arversion }}.gemfile
+      MYSQL_PWD: root
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler: latest
+          bundler-cache: true
+      - name: Start mysql
+        run: sudo systemctl start mysql.service
+      - name: Reset DB
+        run: bundle exec rake turntable:db:reset
+      - name: Run RSpec
+        run: RUBYOPT='-W:deprecated' bundle exec rake spec

--- a/.github/workflows/test_ruby_3_2_trilogy.yml
+++ b/.github/workflows/test_ruby_3_2_trilogy.yml
@@ -1,0 +1,33 @@
+name: Exec Rspec
+run-name: Matrix building for ruby 3.2 ✖️ 【rails 6.1】✖️ Trilogy 🚀
+on: [push]
+
+jobs:
+  ruby_3_0:
+    strategy:
+      fail-fast: false
+      matrix:
+        arversion: ['6_0_6_trilogy', '6_1_7_trilogy']
+    runs-on: ubuntu-22.04
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails${{ matrix.arversion }}.gemfile
+      MYSQL_PWD: root
+      DATABASE_ADAPTER: trilogy
+      DATABASE_PASSWORD: root
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler: latest
+          bundler-cache: true
+      - name: Start mysql
+        run: |
+          sudo systemctl start mysql.service
+          mysql -h 127.0.0.1 --port 3306 -u root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
+      - name: Reset DB
+        run: bundle exec rake turntable:db:reset
+      - name: Run RSpec
+        run: RUBYOPT='-W:deprecated' bundle exec rake spec

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ namespace :turntable do
 
     task :load_config => :rails_env do
       yaml_file = File.join(File.dirname(__FILE__), "spec/config/database.yml")
-      ActiveRecord::Base.configurations = YAML.load ERB.new(IO.read(yaml_file)).result
+      ActiveRecord::Base.configurations = YAML.safe_load ERB.new(IO.read(yaml_file)).result, permitted_classes: [Symbol], aliases: true
     end
 
     desc "create turntable test database"

--- a/lib/active_record/turntable/configuration/loader/yaml.rb
+++ b/lib/active_record/turntable/configuration/loader/yaml.rb
@@ -14,7 +14,7 @@ module ActiveRecord::Turntable
       end
 
       def load(env)
-        yaml = YAML.load(ERB.new(IO.read(path)).result).with_indifferent_access[env]
+        yaml = YAML.safe_load(ERB.new(IO.read(path)).result, permitted_classes: [Symbol], aliases: true).with_indifferent_access[env]
         load_clusters(yaml[:clusters])
         load_global_settings(yaml)
 

--- a/lib/active_record/turntable/connection_proxy/mixable.rb
+++ b/lib/active_record/turntable/connection_proxy/mixable.rb
@@ -9,8 +9,8 @@ module ActiveRecord::Turntable
 
       def mixable?(method, *args)
         (method.to_s =~ METHODS_REGEXP &&
-         args.first !~ EXCLUDE_QUERY_REGEXP) ||
-          (method.to_s == "execute" && args.first =~ QUERY_REGEXP)
+         !(args.first.is_a?(String) && args.first =~ EXCLUDE_QUERY_REGEXP)) ||
+          (method.to_s == "execute" && (args.first.is_a?(String) && args.first =~ QUERY_REGEXP))
       end
     end
   end

--- a/spec/active_record/turntable/active_record_ext/fixture_set_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/fixture_set_spec.rb
@@ -6,7 +6,7 @@ require "active_record/turntable/active_record_ext/fixtures"
 describe ActiveRecord::FixtureSet do
   let(:fixtures_root) { File.join(File.dirname(__FILE__), "../../../fixtures") }
   let(:fixture_file) { File.join(fixtures_root, "items.yml") }
-  let(:items) { YAML.load(ERB.new(IO.read(fixture_file)).result) }
+  let(:items) { YAML.safe_load(ERB.new(IO.read(fixture_file)).result) }
 
   before do
     ActiveRecord::FixtureSet.reset_cache

--- a/spec/active_record/turntable/active_record_ext/log_subscriber_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/log_subscriber_spec.rb
@@ -34,23 +34,23 @@ describe ActiveRecord::Turntable::ActiveRecordExt::LogSubscriber do
     it "ignore SCHEMA log" do
       expect(subscriber.debugs.length).to eq 0
 
-      subscriber.sql(TestEvent.new(name: "bar", turntable_shard_name: "shard_1"))
+      subscriber.sql(TestEvent.new({name: "bar", turntable_shard_name: "shard_1"}))
       expect(subscriber.debugs.length).to eq 1
 
-      subscriber.sql(TestEvent.new(name: "SCHEMA", turntable_shard_name: "shard_1"))
+      subscriber.sql(TestEvent.new({name: "SCHEMA", turntable_shard_name: "shard_1"}))
       expect(subscriber.debugs.length).to eq 1
     end
 
     context "When payload name is `SQL`" do
       it "logs in MAGENTA color" do
-        subscriber.sql(TestEvent.new(name: "SQL", turntable_shard_name: "shard_1"))
+        subscriber.sql(TestEvent.new({name: "SQL", turntable_shard_name: "shard_1"}))
         expect(subscriber.debugs.first).to match(/#{REGEXP_MAGENTA}SQL \(0\.7ms\) \[Shard: shard_1\]#{REGEXP_CLEAR}/)
       end
     end
 
     context "When payload name is `Model Load`" do
       it "logs in CYAN color" do
-        subscriber.sql(TestEvent.new(name: "Model Load", turntable_shard_name: "shard_1"))
+        subscriber.sql(TestEvent.new({name: "Model Load", turntable_shard_name: "shard_1"}))
         expect(subscriber.debugs.first).to match(/#{REGEXP_CYAN}Model Load \(0\.7ms\) \[Shard: shard_1\]#{REGEXP_CLEAR}/)
       end
     end
@@ -59,7 +59,7 @@ describe ActiveRecord::Turntable::ActiveRecordExt::LogSubscriber do
       it "logs binds parameters" do
         binds = [ActiveRecord::Relation::QueryAttribute.new("id", 10, ActiveRecord::Type::Value.new)]
         type_casted_binds = [10]
-        subscriber.sql(TestEvent.new(name: "Model Load", binds: binds, type_casted_binds: type_casted_binds))
+        subscriber.sql(TestEvent.new({name: "Model Load", binds: binds, type_casted_binds: type_casted_binds}))
         expect(subscriber.debugs.first).to match(/\[\["id", 10\]\]/)
       end
     end

--- a/spec/active_record/turntable/active_record_ext/test_fixtures_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/test_fixtures_spec.rb
@@ -12,7 +12,7 @@ describe ActiveRecord::TestFixtures do
   let(:fixture_file) { File.join(fixtures_root, "items.yml") }
   let(:test_fixture_class) { Class.new(ActiveSupport::TestCase) { include ActiveRecord::TestFixtures } }
   let(:test_fixture) { test_fixture_class.new("test") }
-  let(:items) { YAML.load(ERB.new(IO.read(fixture_file)).result) }
+  let(:items) { YAML.safe_load(ERB.new(IO.read(fixture_file)).result) }
 
   describe "#setup_fixtures" do
     after do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ MIGRATIONS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), "migrations
 # in ./support/ and its subdirectories.
 database_yaml = File.read(File.join(File.dirname(__FILE__), "config/database.yml"))
 database_yaml = ERB.new(database_yaml).result
-ActiveRecord::Base.configurations = YAML.load(database_yaml)
+ActiveRecord::Base.configurations = YAML.safe_load(database_yaml, permitted_classes: [Symbol], aliases: true)
 ActiveRecord::Base.establish_connection(:test)
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
- YAML (Psych) のバージョンが上がり、元々 `#load` だったのが `#safe_load` になり、デフォルトのオプションも変わったため、互換になるように修正した 4ad0c4c
- `Object#=~` がなくなり（String と Regexp は残る）、元々結果が nil だったもの（String や Regexp 以外は nil になってた）が落ちるようになったので、String かどうかをチェックするようにした（Regexp は来ないだろうと判断） 72e1306
- Struct に与えたパラメーターが、`new` でそのままキーワード引数にできるようになった影響の修正（元々は payload が Hash を受け取るとしていた） 0b88b88